### PR TITLE
Adding aria-describedby references to autocomplete

### DIFF
--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -26,10 +26,19 @@ $(document).ready(function() {
     }
 
     //======================================================
-    // Assign aria-labelledBy to the dynamically created country input
+    // Assign aria-describedby to the dynamically created country input
+    // Takes the aria-described by value from the select element and
+    // allocates this to the created text input
     //======================================================
+    if (document.querySelectorAll('select[data-all-countries]').length > 0) {
+       var selectDescribedByValues = $('select[data-all-countries]').attr('aria-describedby');
+       $(".autocomplete__wrapper #value").attr('aria-describedby', selectDescribedByValues);
+    }
+    if (document.querySelectorAll('select[data-non-uk-countries]').length > 0) {
+       var selectDescribedByValues = $('select[data-non-uk-countries]').attr('aria-describedby');
+       $(".autocomplete__wrapper #value").attr('aria-describedby', selectDescribedByValues);
+    }
 
-    if ($(".autocomplete-wrapper .error-message").length) $(".autocomplete__wrapper #value").attr('aria-labelledby', 'error-message-input');
 
     //======================================================
     // Fix CSS styling of errors (red outline) around the country input dropdown
@@ -37,9 +46,11 @@ $(document).ready(function() {
 
     // Override autocomplete styles to apply correct error component design pattern
     if ($(".autocomplete-wrapper .error-message").length) $(".autocomplete__wrapper input").addClass('field-error');
+    // Set the border colour to black with orange border when clicking into the input field
     $('.autocomplete__wrapper input').focus(function(e){
         if ($(".autocomplete-wrapper .error-message").length) $(".autocomplete__wrapper input").css({"border" : "4px solid #0b0c0c", "-webkit-box-shadow" : "none", "box-shadow" : "none"});
     })
+    // Set the border colour back to red when clicking out of the input field
     $('.autocomplete__wrapper input').focusout(function(e){
         if ($(".autocomplete-wrapper .error-message").length) $(".autocomplete__wrapper input").css("border", "4px solid #d4351c");
     })

--- a/app/assets/stylesheets/patterns/_autocomplete.scss
+++ b/app/assets/stylesheets/patterns/_autocomplete.scss
@@ -15,3 +15,9 @@
     }
 
 }
+
+.js-enabled {
+    select[data-non-uk-countries] {
+        display: none;
+    }
+}

--- a/app/assets/stylesheets/patterns/_autocomplete.scss
+++ b/app/assets/stylesheets/patterns/_autocomplete.scss
@@ -17,6 +17,9 @@
 }
 
 .js-enabled {
+    select[data-all-countries] {
+        display: none;
+    }
     select[data-non-uk-countries] {
         display: none;
     }

--- a/app/views/components/select.scala.html
+++ b/app/views/components/select.scala.html
@@ -46,7 +46,6 @@
     <select class='form-control @selectClasses.mkString(" ")'
             id="@field.id"
             name="@field.name"
-            aria-labelledby="@{field.id}-label"
             @if(hint.nonEmpty || field.hasErrors) {
             aria-describedby="@if(hint.nonEmpty){form-hint}@if(hint.nonEmpty && field.hasErrors){ }@if(field.hasErrors){error-message-input}"
             }
@@ -60,8 +59,7 @@
                     value="@valueOption.value"
                     @if(field.value.contains(valueOption.value)){
                     selected
-                    }
-            >@messages(valueOption.label)</option>
+                    }>@messages(valueOption.label)</option>
         }
     </select>
 </div>

--- a/app/views/components/select.scala.html
+++ b/app/views/components/select.scala.html
@@ -35,7 +35,7 @@
     </label>
     @if(labelAsHeading){</h1>}
     @hint.map{ hintText =>
-        <span class="form-hint">@messages(hintText)</span>
+        <span id="form-hint" class="form-hint">@messages(hintText)</span>
     }
 
     @field.errors.headOption.map{ error =>
@@ -43,7 +43,15 @@
             <span class="visually-hidden">@messages("site.error")</span> @messages(error.message, error.args:_*)
         </span>
     }
-    <select class='form-control @selectClasses.mkString(" ")' id="@field.id" name="@field.name" aria-labelledby="@field.id-label" @selectAttribute>
+    <select class='form-control @selectClasses.mkString(" ")'
+            id="@field.id"
+            name="@field.name"
+            aria-labelledby="@{field.id}-label"
+            @if(hint.nonEmpty || field.hasErrors) {
+            aria-describedby="@if(hint.nonEmpty){form-hint}@if(hint.nonEmpty && field.hasErrors){ }@if(field.hasErrors){error-message-input}"
+            }
+            @selectAttribute
+    >
         @placeholder.map{ ph =>
             <option value="">@messages(ph)</option>
         }
@@ -52,7 +60,8 @@
                     value="@valueOption.value"
                     @if(field.value.contains(valueOption.value)){
                     selected
-                    }>@messages(valueOption.label)</option>
+                    }
+            >@messages(valueOption.label)</option>
         }
     </select>
 </div>

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -55,6 +55,7 @@ site.service_name = Register and Maintain a Trust
 site.textarea.char_limit = (Limit is {0} characters)
 site.save.continue = Save and continue
 site.sign_out = Sign out
+site.error = Error:
 
 # address lookup component
 address.country = Country


### PR DESCRIPTION
- Select element now has a aria-describedby attribute for non-js enabled
devices
- Js enabled devices now takes the aria-describedby from the select, and
applies this to the generated input#text box (autocomplete). Will
persist the errors and hint text
- Hidden by default the select element when javascript is enabled