### PR TITLE
Add aria-hidden to autocomplete down arrow when enhancing select

### DIFF
--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -40,6 +40,9 @@ $(document).ready(function() {
         $(".autocomplete__wrapper #value").attr('aria-describedby', selectDescribedByValues);
     }
 
+    if (document.querySelectorAll('.autocomplete__dropdown-arrow-down').length) {
+        $('.autocomplete__dropdown-arrow-down').attr('aria-hidden', true);
+    }
 
     //======================================================
     // Fix CSS styling of errors (red outline) around the country input dropdown


### PR DESCRIPTION
The dropdown arrow svg for the accessible-autocomplete component does not have a description.
Make it so `VO + right arrow` command for voiceover cannot set focus state on the svg.

![Screenshot 2021-07-07 at 13 10 41](https://user-images.githubusercontent.com/2979782/124756776-c2814300-df24-11eb-9ca0-83965f47f8fc.png)