### PR TITLE
DDCE-5067: Update to stop form submission with smart apostrophes

### DIFF
--- a/app/forms/mappings/Formatters.scala
+++ b/app/forms/mappings/Formatters.scala
@@ -48,7 +48,7 @@ trait Formatters {
     override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], String] =
       data.get(key) match {
         case None | Some("") => Left(Seq(FormError(key, errorKey)))
-        case Some(s) => Right(s)
+        case Some(s) => Right(s.trim.replace("‘", "'").replace("’", "'"))
       }
 
     override def unbind(key: String, value: String): Map[String, String] =

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -23,11 +23,8 @@ play.http.errorHandler = "handlers.ErrorHandler"
 # Play Modules
 # ~~~~
 # Additional play modules can be added here
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
-play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
 play.filters.enabled += "uk.gov.hmrc.play.bootstrap.frontend.filters.SessionIdFilter"
 play.modules.enabled += "config.Module"
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,10 +2,10 @@ import sbt.*
 
 object AppDependencies {
 
-  val bootstrapVersion = "7.22.0"
+  val bootstrapVersion = "7.23.0"
 
   private lazy val compile = Seq(
-    "uk.gov.hmrc"             %% "play-frontend-hmrc"             % "7.20.0-play-28",
+    "uk.gov.hmrc"             %% "play-frontend-hmrc"             % "7.29.0-play-28",
     "uk.gov.hmrc"             %% "domain"                         % "8.3.0-play-28",
     "uk.gov.hmrc"             %% "play-conditional-form-mapping"  % "1.13.0-play-28",
     "uk.gov.hmrc"             %% "bootstrap-frontend-play-28"     % bootstrapVersion
@@ -13,11 +13,11 @@ object AppDependencies {
 
   private lazy val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"                 %% "bootstrap-test-play-28"   % bootstrapVersion,
-    "org.jsoup"                   %  "jsoup"                    % "1.16.1",
+    "org.jsoup"                   %  "jsoup"                    % "1.17.2",
     "org.scalatest"               %% "scalatest"                % "3.2.17",
     "org.scalatestplus"           %% "scalacheck-1-17"          % "3.2.17.0",
-    "org.mockito"                 %% "mockito-scala-scalatest"  % "1.17.27",
-    "org.wiremock"                %  "wiremock-standalone"      % "3.2.0",
+    "org.mockito"                 %% "mockito-scala-scalatest"  % "1.17.30",
+    "org.wiremock"                %  "wiremock-standalone"      % "3.3.1",
     "io.github.wolfendale"        %% "scalacheck-gen-regexp"    % "1.1.0",
     "com.vladsch.flexmark"        %  "flexmark-all"             % "0.64.8"
   ).map(_ % Test)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )
 
-addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"      % "3.14.0")
+addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"      % "3.20.0")
 addSbtPlugin("uk.gov.hmrc"          % "sbt-distributables"  % "2.2.0")
 addSbtPlugin("com.typesafe.play"    % "sbt-plugin"          % "2.8.20")
 addSbtPlugin("com.beautiful-scala"  % "sbt-scalastyle"      % "1.5.1")

--- a/test/forms/mappings/MappingsSpec.scala
+++ b/test/forms/mappings/MappingsSpec.scala
@@ -53,6 +53,11 @@ class MappingsSpec extends AnyWordSpec with Matchers with OptionValues with Mapp
       result.get mustEqual "foobar"
     }
 
+    "filter out smart apostrophes on binding" in {
+      val boundValue = testForm bind Map("value" -> "We’re ‘aving fish ‘n’ chips for tea")
+      boundValue.get mustEqual "We're 'aving fish 'n' chips for tea"
+    }
+
     "not bind an empty string" in {
       val result = testForm.bind(Map("value" -> ""))
       result.errors must contain(FormError("value", "error.required"))


### PR DESCRIPTION
Trust name form submitted with both smart and normal apostrophes.

![Screenshot 2024-02-02 at 11 56 42](https://github.com/hmrc/register-trust-details-frontend/assets/125281117/7d5b7153-cbbc-494e-9125-02890204ecf5)

![Screenshot 2024-02-02 at 12 00 13](https://github.com/hmrc/register-trust-details-frontend/assets/125281117/0b83a3d9-728c-4355-a8d7-bf88c240f64e)
